### PR TITLE
Add error check venture for assigned ventures

### DIFF
--- a/AutoRetainer/Scheduler/Handlers/RetainerHandlers.cs
+++ b/AutoRetainer/Scheduler/Handlers/RetainerHandlers.cs
@@ -379,4 +379,28 @@ internal unsafe static class RetainerHandlers
         }
         return false;
     }
+
+    internal static bool? CheckForErrorAssignedVenture(uint ventureID)
+    {
+        if (TryGetAddonByName<AddonRetainerTaskAsk>("RetainerTaskAsk", out var addon) && IsAddonReady(&addon->AtkUnitBase))
+        {
+            P.DebugLog($"Checking error");
+            if (addon->AtkUnitBase.UldManager.NodeList[6]->IsVisible)
+            {
+                //An Error is on screen.
+                ClickRetainerTaskAsk.Using((IntPtr)addon).Return();
+                P.DebugLog($"Clicked cancel");
+                P.TaskManager.EnqueueImmediate(() => SelectSpecificVenture(ventureID), "SelectSpecificVenture");
+                P.TaskManager.DelayNextImmediate(10, false);
+                P.TaskManager.EnqueueImmediate(() => CheckForErrorAssignedVenture(ventureID), 500, false, "RedoErrorCheck");
+                return true;
+            }
+        }
+        else
+        {
+            Utils.RethrottleGeneric();
+        }
+        return false;
+    }
+
 }

--- a/AutoRetainer/Scheduler/Tasks/TaskAssignFieldExploration.cs
+++ b/AutoRetainer/Scheduler/Tasks/TaskAssignFieldExploration.cs
@@ -20,6 +20,7 @@ namespace AutoRetainer.Scheduler.Tasks
             P.TaskManager.Enqueue(() => RetainerHandlers.GenericSelectByName(Lang.FieldExplorationNames), "GenericSelectByName");
             P.TaskManager.Enqueue(() => RetainerHandlers.SelectSpecificVenture(VentureID), "SelectSpecificVenture");
             P.TaskManager.DelayNext(10, true);
+            P.TaskManager.Enqueue(() => RetainerHandlers.CheckForErrorAssignedVenture(VentureID), 500, false, "FirstErrorCheck");
             P.TaskManager.Enqueue(RetainerHandlers.ClickAskAssign);
         }
     }

--- a/AutoRetainer/Scheduler/Tasks/TaskAssignHuntingVenture.cs
+++ b/AutoRetainer/Scheduler/Tasks/TaskAssignHuntingVenture.cs
@@ -22,6 +22,7 @@ namespace AutoRetainer.Scheduler.Tasks
             P.TaskManager.Enqueue(() => RetainerHandlers.GenericSelectByName(VentureUtils.GetVentureLevelCategory(VentureID)), $"GenericSelectByName(VentureUtils.GetVentureLevelCategory({VentureID})");
             P.TaskManager.Enqueue(() => RetainerHandlers.SelectSpecificVenture(VentureID), $"SelectSpecificVenture({VentureID})");
             P.TaskManager.DelayNext(10, true);
+            P.TaskManager.Enqueue(() => RetainerHandlers.CheckForErrorAssignedVenture(VentureID), 500, false, "FirstErrorCheck");
             P.TaskManager.Enqueue(RetainerHandlers.ClickAskAssign);
         }
     }


### PR DESCRIPTION
Plugin will loop assigning a venture if an error is on screen. Aimed to alleviate weird game issues where it bugs out and locks out the assign for no reason.