### PR TITLE
Fix error spam during teleports

### DIFF
--- a/AutoRetainer/Helpers/Utils.cs
+++ b/AutoRetainer/Helpers/Utils.cs
@@ -286,6 +286,8 @@ internal static unsafe class Utils
 
     internal static GameObject GetReachableRetainerBell(bool extend)
     {
+        if (Player.Object is null) return null;
+
         foreach (var x in Svc.Objects)
         {
             if ((x.ObjectKind == ObjectKind.Housing || x.ObjectKind == ObjectKind.EventObj) && x.Name.ToString().EqualsIgnoreCaseAny(Lang.BellName))


### PR DESCRIPTION
If you have the MultiModeOverlay open during a teleport, you get a lot of errors in the log about not being able to reach a bell.

This just tightens up checking if the player exists before even looking for a bell to reduce the error spam.