### PR TITLE
new: Настройка для включения телепорта в поместье FC

### DIFF
--- a/AutoRetainer/AutoRetainer.csproj
+++ b/AutoRetainer/AutoRetainer.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<Authors>Puni.sh</Authors>
-		<Version>4.2.2.0</Version>
+		<Version>4.2.2.1</Version>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/AutoRetainer/Modules/Multi/MultiMode.cs
+++ b/AutoRetainer/Modules/Multi/MultiMode.cs
@@ -33,7 +33,7 @@ internal unsafe static class MultiMode
     internal static CircularBuffer<long> Interactions = new(5);
 
     internal static Dictionary<ulong, int> CharaCnt = new();
-    internal static bool CanHET => Active && C.ExpertMultiAllowHET && ResidentalAreas.List.Contains(Svc.ClientState.TerritoryType);
+    internal static bool CanHET => Active && C.ExpertMultiAllowHET && (ResidentalAreas.List.Contains(Svc.ClientState.TerritoryType) || Data.TeleportToFCHouse);
 
     internal static void Init()
     {

--- a/AutoRetainer/UI/MultiModeUI.cs
+++ b/AutoRetainer/UI/MultiModeUI.cs
@@ -141,6 +141,11 @@ internal unsafe static class MultiModeUI
                     P.DuplicateBlacklistSelector.IsOpen = true;
                     P.DuplicateBlacklistSelector.SelectedData = data;
                 }
+                var inst = Svc.PluginInterface.InstalledPlugins.Any(x => x.InternalName == "TeleporterPlugin" && x.IsLoaded);
+                if (!inst) ImGui.BeginDisabled();
+                ImGui.Checkbox($"Teleport to FC house if not in housing zone upon logging in during multi mode", ref data.TeleportToFCHouse);
+                if (!inst) ImGui.EndDisabled();
+                ImGuiComponents.HelpMarker("You must have Teleporter plugin installed and enabled to use this function.");
                 ImGui.Separator();
                 if (ImGuiEx.ButtonCtrl("Exclude Character"))
                 {


### PR DESCRIPTION
Adds a per-character setting to allow for teleport to the FC estate via use of the Teleporter plugin if when logging in during multi mode operation the character is not in a housing zone.