### PR TITLE
Fix integration with Artisan not allowing access to retainers

### DIFF
--- a/AutoRetainer/Scheduler/Artisan.cs
+++ b/AutoRetainer/Scheduler/Artisan.cs
@@ -21,19 +21,21 @@ internal static class Artisan
         {
             if (IsCurrentlyOperating() && MultiMode.EnsureCharacterValidity(true))
             {
-                if(!SchedulerMain.PluginEnabled || SchedulerMain.Reason != PluginEnableReason.Artisan)
-                {
-                    SchedulerMain.EnablePlugin(PluginEnableReason.Artisan);
-                    DebugLog($"Enabling AutoRetainer because of Artisan integration");
-                }
                 try
                 {
-                    if (AnyRetainersAvailable())
+                    var bell = Utils.GetReachableRetainerBell(true);
+                    if (AnyRetainersAvailable() && bell != null)
                     {
                         if (!WasPaused)
                         {
                             WasPaused = true;
                             SetStopRequest(true);
+                        }
+
+                        if (!SchedulerMain.PluginEnabled || SchedulerMain.Reason != PluginEnableReason.Artisan)
+                        {
+                            SchedulerMain.EnablePlugin(PluginEnableReason.Artisan);
+                            DebugLog($"Enabling AutoRetainer because of Artisan integration");
                         }
                     }
                 }

--- a/AutoRetainer/Scheduler/SchedulerMain.cs
+++ b/AutoRetainer/Scheduler/SchedulerMain.cs
@@ -214,9 +214,9 @@ internal unsafe static class SchedulerMain
                                     }
                                     else if (Reason == PluginEnableReason.Artisan)
                                     {
-                                        DebugLog($"Scheduling closing  as Artisan is running");
+                                        DebugLog($"Scheduling closing as Artisan is running");
                                         P.TaskManager.Enqueue(RetainerListHandlers.CloseRetainerList);
-                                        //P.TaskManager.Enqueue(DisablePlugin);
+                                        P.TaskManager.Enqueue(DisablePlugin);
                                     }
                                     else
                                     {


### PR DESCRIPTION
- No longer sets the plugin to enabled during Artisan execution if retainers are not available.
- Disables plugin after finishing Artisan execution to allow normal access to retainers.