### PR TITLE
add auto desynth to IM

### DIFF
--- a/AutoRetainer/Configuration/Config.cs
+++ b/AutoRetainer/Configuration/Config.cs
@@ -194,6 +194,7 @@ internal unsafe class Config : IEzConfig
     public int IMAutoVendorHardStackLimit = 20;
     public bool IMDry = false;
     public bool TreatSoftAsHard = false;
+    public bool IMEnableItemDesynthesis = false;
 
     public Vector2 WindowSize;
     public Vector2 WindowPos;

--- a/AutoRetainer/Internal/InventoryManagement/InventorySpaceManager.cs
+++ b/AutoRetainer/Internal/InventoryManagement/InventorySpaceManager.cs
@@ -1,4 +1,5 @@
-﻿using ECommons.ExcelServices;
+﻿using AutoRetainer.Scheduler.Tasks;
+using ECommons.ExcelServices;
 using ECommons.Throttlers;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
@@ -117,7 +118,7 @@ public static unsafe class InventorySpaceManager
                 var item = inv->Items[i];
                 if (item.ItemId != 0 && item.Quantity < C.IMAutoVendorHardStackLimit)
                 {
-                    if (C.IMAutoVendorHard.Contains(item.ItemId) || (C.TreatSoftAsHard && C.IMAutoVendorSoft.Contains(item.ItemId)))
+                    if ((C.IMAutoVendorHard.Contains(item.ItemId) || (C.TreatSoftAsHard && C.IMAutoVendorSoft.Contains(item.ItemId))) && !TaskDesynthItems.DesynthEligible(item.ItemId))
                     {
                         var task = new SellSlotTask(invType, (uint)i, item.ItemId, item.Quantity);
                         PluginLog.Information($"Enqueueing {task} for hard sale");

--- a/AutoRetainer/Scheduler/SchedulerMain.cs
+++ b/AutoRetainer/Scheduler/SchedulerMain.cs
@@ -211,6 +211,7 @@ internal static unsafe class SchedulerMain
                                         P.TaskManager.Enqueue(RetainerListHandlers.CloseRetainerList);
                                         P.TaskManager.Enqueue(DisablePlugin);
                                         if (C.IMEnableCofferAutoOpen) TaskOpenAllCoffers.Enqueue();
+                                        if (C.IMEnableItemDesynthesis) TaskDesynthItems.Enqueue();
                                     }
                                     else if (Reason == PluginEnableReason.Artisan)
                                     {

--- a/AutoRetainer/Scheduler/Tasks/TaskDesynthItems.cs
+++ b/AutoRetainer/Scheduler/Tasks/TaskDesynthItems.cs
@@ -1,0 +1,97 @@
+﻿using Dalamud.Game.ClientState.Conditions;
+using ECommons.ExcelServices;
+using ECommons.Throttlers;
+using FFXIVClientStructs.FFXIV.Client.Game;
+using FFXIVClientStructs.FFXIV.Client.Game.UI;
+using FFXIVClientStructs.FFXIV.Client.UI.Agent;
+using FFXIVClientStructs.FFXIV.Component.GUI;
+using FFXIVClientStructs.Interop;
+using ValueType = FFXIVClientStructs.FFXIV.Component.GUI.ValueType;
+
+namespace AutoRetainer.Scheduler.Tasks;
+public static unsafe class TaskDesynthItems
+{
+    private unsafe delegate void SalvageItemDelegate(AgentSalvage* thisPtr, InventoryItem* item, int addonId, byte a4);
+    private static SalvageItemDelegate _salvageItem = null!;
+    private static readonly InventoryType[] DesynthableInventories =
+    [
+        InventoryType.Inventory1,
+        InventoryType.Inventory2,
+        InventoryType.Inventory3,
+        InventoryType.Inventory4,
+        InventoryType.ArmoryMainHand,
+        InventoryType.ArmoryOffHand,
+        InventoryType.ArmoryHead,
+        InventoryType.ArmoryBody,
+        InventoryType.ArmoryHands,
+        InventoryType.ArmoryLegs,
+        InventoryType.ArmoryFeets,
+        InventoryType.ArmoryEar,
+        InventoryType.ArmoryNeck,
+        InventoryType.ArmoryWrist,
+        InventoryType.ArmoryRings
+    ];
+
+    public static void Enqueue()
+    {
+        P.TaskManager.Enqueue(RecursivelyDesynthItems, 10 * 60 * 1000, false);
+        P.TaskManager.Enqueue(() => !Svc.Condition[ConditionFlag.Occupied39]);
+    }
+
+    private static bool? RecursivelyDesynthItems()
+    {
+        if (!QuestManager.IsQuestComplete(65688)) return true;
+        _salvageItem = Marshal.GetDelegateForFunctionPointer<SalvageItemDelegate>(Svc.SigScanner.ScanText("E8 ?? ?? ?? ?? EB 46 48 8B 03"));
+
+        var eligibleItems = GetEligibleItems();
+        if (eligibleItems.Count == 0) return true;
+
+        foreach (var item in eligibleItems)
+        {
+            // check IsOccupied vs just Occupied39 or else it might trigger when exiting the retainer menu
+            if (Utils.AnimationLock == 0 && !IsOccupied())
+            {
+                if (Utils.GenericThrottle && EzThrottler.Throttle("DesynthingItem", 1000))
+                    DesynthItem(item);
+            }
+            else
+                Utils.RethrottleGeneric();
+        }
+        return false;
+    }
+
+    private static List<Pointer<InventoryItem>> GetEligibleItems()
+    {
+        List<Pointer<InventoryItem>> items = [];
+        foreach (var inv in DesynthableInventories)
+        {
+            var cont = InventoryManager.Instance()->GetInventoryContainer(inv);
+            for (var i = 0; i < cont->Size; ++i)
+            {
+                var item = cont->GetInventorySlot(i);
+                if (IsOnIMList(item->ItemId) && DesynthEligible(item->ItemId))
+                    items.Add(item);
+            }
+        }
+        return items;
+    }
+
+    public static bool DesynthEligible(uint itemID)
+        => C.IMEnableItemDesynthesis
+        && ExcelItemHelper.Get(itemID).Desynth > 0
+        && PlayerState.Instance()->ClassJobLevels[(int)ExcelItemHelper.Get(itemID).ClassJobRepair.Value.RowId] >= 30;
+
+    private static bool IsOnIMList(uint itemID) => !C.IMProtectList.Contains(itemID) && (C.IMAutoVendorHard.Contains(itemID) || (C.TreatSoftAsHard && C.IMAutoVendorSoft.Contains(itemID)));
+
+    private static void DesynthItem(InventoryItem* item)
+    {
+        Svc.Log.Info($"Desynthing {ExcelItemHelper.GetName(ExcelItemHelper.Get(item->ItemId), true)} [Container={item->Container},Slot={item->Slot}]");
+        _salvageItem(AgentSalvage.Instance(), item, 0, 0);
+        var retval = new AtkValue();
+        Span<AtkValue> param = [
+            new AtkValue { Type = ValueType.Int, Int = 0 },
+            new AtkValue { Type = ValueType.Bool, Byte = 1 }
+        ];
+        AgentSalvage.Instance()->AgentInterface.ReceiveEvent(&retval, param.GetPointer(0), 2, 1);
+    }
+}

--- a/AutoRetainer/UI/NeoUI/AdvancedEntries/DebugSection/DebugScheduler.cs
+++ b/AutoRetainer/UI/NeoUI/AdvancedEntries/DebugSection/DebugScheduler.cs
@@ -198,5 +198,10 @@ internal unsafe class DebugScheduler : DebugUIEntry
                 }
             }
         }
+
+        ImGui.Separator();
+
+        if (ImGui.Button("TaskDesynthItems"))
+            TaskDesynthItems.Enqueue();
     }
 }

--- a/AutoRetainer/UI/NeoUI/InventoryManagementEntries/InventoryManagementTab.cs
+++ b/AutoRetainer/UI/NeoUI/InventoryManagementEntries/InventoryManagementTab.cs
@@ -13,6 +13,7 @@ public unsafe class InventoryManagementTab : NeoUIEntry
     {
         ImGui.Checkbox($"Auto-open coffers", ref C.IMEnableCofferAutoOpen);
         ImGui.Checkbox($"Auto-vendor items", ref C.IMEnableAutoVendor);
+        ImGui.Checkbox($"Auto-desynth items", ref C.IMEnableItemDesynthesis);
         ImGui.Checkbox($"Enable context menu integration", ref C.IMEnableContextMenu);
         ImGui.InputInt($"Hard list max stack size", ref C.IMAutoVendorHardStackLimit);
         ImGui.Checkbox($"Dry mode", ref C.IMDry);


### PR DESCRIPTION
Adds the option to desynth items in the IM list as a task that occurs post open coffers
`InventorySpaceManager` was modified so that if you did have an item that you wanted to be desynthed it wouldn't be sold first since vendor runs before this new task.

Desynth itself relies on a quest having been completed to unlock it so I check for that and also each crafter has to be >=30 in order to desynth the related items so there's checks for that too and it should just return as completed if the requirements aren't met