### PR TITLE
Fixed workshop entrance detection for GER client

### DIFF
--- a/AutoRetainer/Lang.cs
+++ b/AutoRetainer/Lang.cs
@@ -2,6 +2,7 @@
 using Dalamud.Utility;
 using Lumina.Excel.GeneratedSheets;
 using System.Collections.ObjectModel;
+using System.Text.RegularExpressions;
 
 namespace AutoRetainer;
 
@@ -186,7 +187,11 @@ internal static class Lang
     internal static readonly string[] PanelSubmersible = ["Select a submersible.", "潜水艦を選択してください。", "请选择潜水艇。", "請選擇潛水艇。", "Wähle ein Tauchboot.", "Choisissez un sous-marin."];
 
     //2004353	entrance to additional chambers	0	entrances to additional chambers	0	1	1	0	0
-    internal static string AdditionalChambersEntrance => Svc.Data.GetExcelSheet<EObjName>().GetRow(2004353).Singular.ExtractText();
+    internal static string[] AdditionalChambersEntrance => 
+    [
+        Svc.Data.GetExcelSheet<EObjName>().GetRow(2004353).Singular.ExtractText(),
+        Regex.Replace(Svc.Data.GetExcelSheet<EObjName>().GetRow(2004353).Singular.ExtractText(), @"\[.*?\]", "")
+    ];
 
     //2005274	voyage control panel	0	voyage control panels	0	0	1	0	0
     internal static string PanelName => Svc.Data.GetExcelSheet<EObjName>().GetRow(2005274).Singular.ExtractText();


### PR DESCRIPTION
Multi-mode submersibles are currently not working when you set the client language to German because AR fails to detect the workshop entrance.
This is because the name string for the workshop entrance object ingame is "Eingang zu anderen Zimmern" while the current Excel lookup resolves to "Eingang[p] zu anderen Zimmern". The string comparison then fails of course.

Since I could not find a Dalamud- or game-specific solution to filter the "[p]" out, which I believe to be some localization/pluralization tag, I added another string to the comparison list that filters out all text in square brackets from the Excel lookup via Regex.
I tested this to work in all languages available to me (JP, EN, GER, FR).

Other solutions could be:
- Just adding the hardcoded string "Eingang zu anderen Zimmern" to the comparison list like done for Lang.BellName. In contrast to that the string is not entirely different from the Excel Row like in that case so I thought my solution would be more future proof.
- Extracting the logic of adding a filtered string to the comparison into a helper function in Lang.cs. As this is AFAIK the only occurence of this issue so far, I did not yet see a need for that function.

I am happy to change to an alternative solution, if you have an different preference / more input.