### PR TITLE
Add GetMultiModeStatus method for IPC

### DIFF
--- a/AutoRetainer/Modules/EzIPCManagers/IPC_PluginState.cs
+++ b/AutoRetainer/Modules/EzIPCManagers/IPC_PluginState.cs
@@ -1,4 +1,4 @@
-﻿using AutoRetainer.Internal;
+using AutoRetainer.Internal;
 using AutoRetainer.Modules.Voyage;
 using ECommons.EzIpcManager;
 using FFXIVClientStructs.FFXIV.Client.Game;
@@ -22,6 +22,7 @@ public class IPC_PluginState
         SchedulerMain.DisablePlugin();
         VoyageScheduler.Enabled = false;
     }
+    [EzIPC] public bool GetMultiModeStatus() => MultiMode.Enabled;
     [EzIPC] public void EnableMultiMode() => Svc.Commands.ProcessCommand("/autoretainer multi enable");
     [EzIPC] public int GetInventoryFreeSlotCount() => Utils.GetInventoryFreeSlotCount();
     [EzIPC] public void EnqueueHET(Action onFailure) => TaskNeoHET.Enqueue(onFailure);


### PR DESCRIPTION
This adds a single method to check the multi mode status through IPC.

I'm currently making a plugin where this single feature would solve most of my issues, so would be immensely helpful if it were to be merged.

Thank you for the plugin, and for your time to look at this. 