### PR TITLE
Fix premature sub plan change

### DIFF
--- a/AutoRetainer/Modules/Voyage/PartSwapper/PartSwapperScheduler.cs
+++ b/AutoRetainer/Modules/Voyage/PartSwapper/PartSwapperScheduler.cs
@@ -24,7 +24,8 @@ public static unsafe class PartSwapperScheduler
                                   {
                                       var plan = PartSwapperUtils.GetPlanInLevelRange(Data.GetAdditionalVesselData(next, type).Level);
                                       if (plan == null) return;
-                                      if (PartSwapperUtils.GetIsVesselNeedsPartsSwap(next, VoyageType.Submersible, out _).Count == 0)
+                                      var partSwapperList = PartSwapperUtils.GetIsVesselNeedsPartsSwap(next, VoyageType.Submersible, out _);
+                                      if (partSwapperList is { Count: 0 })
                                       {
                                           if (plan.FirstSubDifferent && VoyageUtils.GetVesselIndexByName(next, VoyageType.Submersible) == 0)
                                           {

--- a/AutoRetainer/Modules/Voyage/PartSwapper/PartSwapperUtils.cs
+++ b/AutoRetainer/Modules/Voyage/PartSwapper/PartSwapperUtils.cs
@@ -10,12 +10,12 @@ using System.Threading.Tasks;
 namespace AutoRetainer.Modules.Voyage.PartSwapper;
 public unsafe static class PartSwapperUtils
 {
-    internal static List<(int, uint)> GetIsVesselNeedsPartsSwap(string name, VoyageType type, out List<string> log)
+    internal static List<(int, uint)>? GetIsVesselNeedsPartsSwap(string name, VoyageType type, out List<string> log)
     {
         return GetIsVesselNeedsPartsSwap(VoyageUtils.GetVesselIndexByName(name, type), type, out log);
     }
 
-    internal static List<(int, uint)> GetIsVesselNeedsPartsSwap(int num, VoyageType type, out List<string> log)
+    internal static List<(int, uint)>? GetIsVesselNeedsPartsSwap(int num, VoyageType type, out List<string> log)
     {
         log = [];
         var workshop = HousingManager.Instance()->WorkshopTerritory;
@@ -25,7 +25,7 @@ public unsafe static class PartSwapperUtils
 
         CheckAndLogParts(num, type, GetPlanInLevelRange(vesselLevel), log, out var requiredChanges);
 
-        return AreRequiredPartsAvailable(requiredChanges) ? requiredChanges : [];
+        return AreRequiredPartsAvailable(requiredChanges) ? requiredChanges : null;
     }
 
     internal static LevelAndPartsData? GetPlanInLevelRange(int vesselLevel)

--- a/AutoRetainer/Modules/Voyage/Tasks/TaskIntelligentComponentsChange.cs
+++ b/AutoRetainer/Modules/Voyage/Tasks/TaskIntelligentComponentsChange.cs
@@ -15,7 +15,7 @@ internal static class TaskIntelligentComponentsChange
         {
             if (PartSwapperUtils.GetPlanInLevelRange(Data.GetAdditionalVesselData(name, type).Level) == null) return;
             var rep = PartSwapperUtils.GetIsVesselNeedsPartsSwap(name, type, out var log);
-            if(rep.Count > 0)
+            if(rep is { Count: > 0 })
             {
                 TaskChangeComponents.EnqueueImmediate(rep, name, type);
             }

--- a/AutoRetainer/UI/NeoUI/RetainersTab.cs
+++ b/AutoRetainer/UI/NeoUI/RetainersTab.cs
@@ -110,7 +110,7 @@ public class RetainersTab : NeoUIEntry
             foreach (var x in SelectedRetainers)
             {
                 var odata = C.OfflineData.FirstOrDefault(z => z.CID == x.CID);
-                if (odata != null)
+                if (odata != null && SelectedVenturePlan != null)
                 {
                     var adata = Utils.GetAdditionalData(x.CID, x.RetainerName);
                     adata.VenturePlan = SelectedVenturePlan;


### PR DESCRIPTION
Preset plans were changed even though there aren't all needed sub parts available.

Additionally the PR includes the mass retainer change fix that is already implemented in 4.5.0.4 but not yet in this repo.