### PR TITLE
Include all possible GilShops

### DIFF
--- a/AutoRetainer/Internal/InventoryManagement/NpcSaleManager.cs
+++ b/AutoRetainer/Internal/InventoryManagement/NpcSaleManager.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Game.ClientState.Objects.Types;
+using Dalamud.Game.ClientState.Objects.Types;
 using ECommons.GameFunctions;
 using ECommons.GameHelpers;
 using ECommons.Throttlers;
@@ -6,6 +6,7 @@ using ECommons.UIHelpers.AddonMasterImplementations;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.Game.Control;
 using FFXIVClientStructs.FFXIV.Component.GUI;
+using Lumina.Excel;
 using Lumina.Excel.Sheets;
 
 namespace AutoRetainer.Internal.InventoryManagement;
@@ -120,7 +121,7 @@ public static unsafe class NpcSaleManager
         }
     }
 
-    public static uint[] VendorDataID = [1008837, 1008838, 1008839, 1008840, 1008841, 1008842, 1008843, 1008844, 1008845, 1008846, 1013117, 1013118, 1008847, 1008848, 1008849, 1008850, 1008855, 1008854, 1008853, 1008852, 1008851, 1008856, 1013119, 1013120, 1016176, 1016177, 1016178, 1016179, 1016180, 1016181, 1016182, 1016183, 1016184, 1016185, 1016186, 1016187, 1018662, 1018663, 1018664, 1018665, 1018666, 1018667, 1018668, 1018669, 1018670, 1018671, 1018672, 1018673, 1018675, 1018674, 1018676, 1018677, 1018678, 1018679, 1018680, 1018681, 1018682, 1018683, 1018684, 1018685, 1024549, 1024548, 1024550, 1024551, 1024552, 1024553, 1024554, 1024555, 1024556, 1024557, 1024558, 1024559, 1024560, 1024561, 1024562, 1024563, 1024564, 1024565, 1024566, 1024567, 1024568, 1024569, 1024570, 1024571, 1025027, 1025028, 1025029, 1025030, 1025031, 1025032, 1025033, 1025034, 1025035, 1025036, 1025037, 1025038, 1025039, 1025040, 1025042, 1025043, 1025044, 1025046, 1025717, 1026169, 1025718, 1026170, 1025720, 1026172, 1025913, 1025914, 1025915, 1025916, 1025917, 1025918, 1025922, 1025923, 1025924, 1025921, 1025920, 1025919, 1027015, 1027016, 1027018, 1045242, 1045256, 1045257, 1045243, 1045245, 1045259];
+    /*public static uint[] VendorDataID = [1008837, 1008838, 1008839, 1008840, 1008841, 1008842, 1008843, 1008844, 1008845, 1008846, 1013117, 1013118, 1008847, 1008848, 1008849, 1008850, 1008855, 1008854, 1008853, 1008852, 1008851, 1008856, 1013119, 1013120, 1016176, 1016177, 1016178, 1016179, 1016180, 1016181, 1016182, 1016183, 1016184, 1016185, 1016186, 1016187, 1018662, 1018663, 1018664, 1018665, 1018666, 1018667, 1018668, 1018669, 1018670, 1018671, 1018672, 1018673, 1018675, 1018674, 1018676, 1018677, 1018678, 1018679, 1018680, 1018681, 1018682, 1018683, 1018684, 1018685, 1024549, 1024548, 1024550, 1024551, 1024552, 1024553, 1024554, 1024555, 1024556, 1024557, 1024558, 1024559, 1024560, 1024561, 1024562, 1024563, 1024564, 1024565, 1024566, 1024567, 1024568, 1024569, 1024570, 1024571, 1025027, 1025028, 1025029, 1025030, 1025031, 1025032, 1025033, 1025034, 1025035, 1025036, 1025037, 1025038, 1025039, 1025040, 1025042, 1025043, 1025044, 1025046, 1025717, 1026169, 1025718, 1026170, 1025720, 1026172, 1025913, 1025914, 1025915, 1025916, 1025917, 1025918, 1025922, 1025923, 1025924, 1025921, 1025920, 1025919, 1027015, 1027016, 1027018, 1045242, 1045256, 1045257, 1045243, 1045245, 1045259];
     public static uint[] VendorDataIDGilShop //doesn't works?
     {
         get
@@ -128,7 +129,9 @@ public static unsafe class NpcSaleManager
             field ??= [..Svc.Data.GetExcelSheet<ENpcBase>().Where(cls => cls.ENpcData.Any(data => data.Is<GilShop>())).Select(x => x.RowId)];
             return field;
         }
-    }
+    }*/
+	
+	public static uint[] VendorDataID = Svc.Data.GetExcelSheet<ENpcBase>().Where(cls => cls.ENpcData.Any(data => (data.Is<PreHandler>() && data.TryGetValue(out PreHandler preHandler) && preHandler.Target.Is<GilShop>()) || data.Is<GilShop>() || (data.Is<TopicSelect>() && data.TryGetValue(out TopicSelect topicSelect) && topicSelect.Shop.Any(x => x.Is<GilShop>())))).Select(x => x.RowId).ToArray();
 
     public static IGameObject GetValidNPC()
     {
@@ -142,7 +145,7 @@ public static unsafe class NpcSaleManager
 
     public static bool? InteractWithNPC()
     {
-        if(TryGetAddonByName<AtkUnitBase>("SelectIconString", out _)) return true;
+        if(TryGetAddonByName<AtkUnitBase>("SelectIconString", out _) || TryGetAddonByName<AtkUnitBase>("Shop", out _)) return true;
         var npc = GetValidNPC() ?? throw new InvalidOperationException("Could not find housing NPC");
         if(Svc.Targets.Target?.Address != npc.Address)
         {
@@ -166,13 +169,13 @@ public static unsafe class NpcSaleManager
     public static bool? SelectPurchase()
     {
         if(TryGetAddonByName<AtkUnitBase>("Shop", out var addon) && IsAddonReady(addon)) return true;
-        if(TryGetAddonMaster<AddonMaster.SelectIconString>(out var m))
+		if (TryGetAddonMaster<AddonMaster.SelectIconString>(out var iconStringM))
         {
-            foreach(var entry in m.Entries)
+            foreach(var entry in iconStringM.Entries)
             {
-                if(Svc.Data.GetExcelSheet<GilShop>().Select(x => x.Name.GetText()).Contains(entry.Text))
+                if(Svc.Data.GetExcelSheet<GilShop>().Select(x => x.Name.GetText()).Contains(entry.Text) || Svc.Data.GetExcelSheet<TopicSelect>().Where(x => x.Shop.Any(y => y.Is<GilShop>())).Select(x => x.Name.GetText()).Contains(entry.Text))
                 {
-                    if(EzThrottler.Throttle("SelectStringSell", 2000))
+                    if(EzThrottler.Throttle("SelectIconStringSell", 2000))
                     {
                         entry.Select();
                     }
@@ -180,12 +183,23 @@ public static unsafe class NpcSaleManager
                 }
             }
         }
-        return false;
+        if (TryGetAddonMaster<AddonMaster.SelectString>(out var stringM)) {
+	        foreach (var entry in stringM.Entries) {
+		        if (Svc.Data.GetExcelSheet<GilShop>().Select(x => x.Name.GetText()).Contains(entry.Text)) {
+			        if (EzThrottler.Throttle("SelectStringSell", 2000)) {
+				        entry.Select();
+			        }
+			        return false;
+		        }
+	        }
+        }
+		return false;
     }
 
     public static bool? CloseShop()
     {
-        if(TryGetAddonByName<AtkUnitBase>("Shop", out var addon) && IsAddonReady(addon))
+	    AtkUnitBase* addon;
+        if((TryGetAddonByName("Shop", out addon) || TryGetAddonByName("SelectString", out addon)) && IsAddonReady(addon))
         {
             if(EzThrottler.Throttle("CloseShop", 2000))
             {
@@ -193,9 +207,12 @@ public static unsafe class NpcSaleManager
             }
             return false;
         }
-        else
+        else if (ECommons.GameHelpers.Player.IsBusy)
         {
-            return true;
+	        return false;
         }
+		else {
+			return true;
+		}
     }
 }


### PR DESCRIPTION
This worked so far over the last few weeks/months with all the different overworld NPCs I tried it with and the housing NPCs I set up.
Didn't test every single housing NPC though...  users would have to try and report, so we can readjust it.

You maybe want to find a "better" solution for closing the shop though, as it has to close the SelectString too and the easiest way out for now was an additional Player.IsBusy check.

EDIT:
Also maybe lower the Throttle of CloseShop down to less than 2 seconds, else it needs a good amount of time to get through those 2-3 closing steps.