### PR TITLE
Add Spanish retainer strings

### DIFF
--- a/AutoRetainer/AutoRetainer.cs
+++ b/AutoRetainer/AutoRetainer.cs
@@ -258,7 +258,7 @@ public unsafe class AutoRetainer : IDalamudPlugin
             //4330	57	33	0	False	リテイナーベンチャー「<Value>IntegerParameter(2)</Value> <Sheet(Item,IntegerParameter(1),0)/>」を依頼しました。
             //4330	57	33	0	False	Du hast deinen Gehilfen mit der Beschaffung von <SheetDe(Item,1,IntegerParameter(1),IntegerParameter(3),3,1)/> ( <Value>IntegerParameter(2)</Value>) beauftragt.
             //4330	57	33	0	False	Vous avez confié la tâche “<SheetFr(Item,12,IntegerParameter(1),2,1)/> ( <Value>IntegerParameter(2)</Value>)” à votre servant.
-            if(text.StartsWithAny("You assign your retainer".Cleanup(), "リテイナーベンチャー".Cleanup(), "Du hast deinen Gehilfen mit".Cleanup(), "Vous avez confié la tâche".Cleanup())
+            if(text.StartsWithAny("You assign your retainer".Cleanup(), "リテイナーベンチャー".Cleanup(), "Du hast deinen Gehilfen mit".Cleanup(), "Vous avez confié la tâche".Cleanup(), "Asignas a tu sirviente".Cleanup())
                 && Utils.TryGetCurrentRetainer(out var ret)
                 && C.OfflineData.TryGetFirst(x => x.CID == Svc.ClientState.LocalContentId, out var offlineData)
                 && offlineData.RetainerData.TryGetFirst(x => x.Name == ret, out var offlineRetainerData))

--- a/AutoRetainer/Lang.cs
+++ b/AutoRetainer/Lang.cs
@@ -77,6 +77,10 @@ internal static class Lang
         "탐색수행: 산악 (필요한 집사 급료: 2개)",
         "탐색수행: 삼림 (필요한 집사 급료: 2개)",
         "탐색수행: 물가 (필요한 집사 급료: 2개)",
+        "Exploración de llanura.",
+        "Exploración de montaña.",
+        "Exploración de bosque.",
+        "Exploración de ribera.",
     ];
 
     internal static readonly string[] HuntingVentureNames =
@@ -109,6 +113,10 @@ internal static class Lang
         "조달수행: 광부 (필요한 집사 급료: 1개)",
         "조달수행: 원예가 (필요한 집사 급료: 1개)",
         "조달수행: 어부 (필요한 집사 급료: 1개)",
+        "Caza.",
+        "Minería.",
+        "Botánica.",
+        "Pesca.",
     ];
 
     internal static readonly string[] QuickExploration =
@@ -121,6 +129,7 @@ internal static class Lang
         "自由探索委託（需要2枚探險幣）",
         "발굴수행 (필요한 집사 급료: 2개)",
         "自由尋寶委託（需要2枚探險幣）",
+        "Exploración rápida.",
     ];
 
     internal static readonly string[] Entrance =
@@ -156,9 +165,10 @@ internal static class Lang
         "Choisissez un type de tâche :",
         "Select a category.",
         "집사 수행의 종류를 선택하십시오.",
+        "Seleccione una categoría.",
     ];
 
-    internal static string[] BellName => [Svc.Data.GetExcelSheet<EObjName>().GetRow(2000401).Singular.GetText(), "リテイナーベル"];
+    internal static string[] BellName => [Svc.Data.GetExcelSheet<EObjName>().GetRow(2000401).Singular.GetText(), "リテイナーベル", "campanilla"];
 
     //0	TEXT_HOUFIXMANSIONENTRANCE_00359_HOUSINGAREA_MENU_ENTER_MYROOM	Go to your apartment
     //0	TEXT_HOUFIXMANSIONENTRANCE_00359_HOUSINGAREA_MENU_ENTER_MYROOM	自分の部屋に移動する
@@ -306,7 +316,23 @@ internal static class Lang
 
     internal static string[] WillBeUnableToProcessBuyback => field ??= [
         Svc.Data.GetExcelSheet<QuestDialogueText>(name:"custom/000/CmnDefRetainerCall_00010").GetRow(215).Value.GetText(),
+        "Una vez que lo haga volver, su sirviente no podrá gestionar recompras de objetos. ¿Seguro que desea continuar?",
         ];
+
+    //2385	View venture report. (Complete)
+    internal static readonly string[] ViewVentureReportComplete = ["Ver informe de expedición. (Completada)"];
+
+    //2386	Assign venture.        2387	Assign venture. (In progress)
+    internal static readonly string[] AssignVenture = ["Asignar expedición."];
+
+    //2383	Quit.
+    internal static readonly string[] QuitRetainerMenu = ["Salir."];
+
+    //2378	Entrust or withdraw items. (Slots filled: …)
+    internal static readonly string[] EntrustOrWithdrawItems = ["Entregar o retirar objetos."];
+
+    //2379	Entrust or withdraw gil. (Gil entrusted: …)
+    internal static readonly string[] EntrustOrWithdrawGil = ["Entregar o retirar gil."];
 
     //3290	<Sheet(Item,IntegerParameter(1),0)/>×<Value>IntegerParameter(2)</Value>を、<Format(IntegerParameter(3),FF022C)/>枚の軍票と交換します。
     //よろしいですか？

--- a/AutoRetainer/Scheduler/Handlers/RetainerHandlers.cs
+++ b/AutoRetainer/Scheduler/Handlers/RetainerHandlers.cs
@@ -44,7 +44,7 @@ internal static unsafe class RetainerHandlers
     internal static bool? SelectAssignVenture()
     {
         var text = new string[] { Svc.Data.GetExcelSheet<Lumina.Excel.Sheets.Addon>().GetRow(2386).Text.ToDalamudString().GetText(), Svc.Data.GetExcelSheet<Lumina.Excel.Sheets.Addon>().GetRow(2387).Text.ToDalamudString().GetText() };
-        return Utils.TrySelectSpecificEntry(text);
+        return Utils.TrySelectSpecificEntry([.. text, .. Lang.AssignVenture]);
     }
 
     internal static bool? SelectQuit()
@@ -59,7 +59,7 @@ internal static unsafe class RetainerHandlers
             return false;
         }
         var text = Svc.Data.GetExcelSheet<Lumina.Excel.Sheets.Addon>().GetRow(2383).Text.ToDalamudString().GetText();
-        return Utils.TrySelectSpecificEntry(text);
+        return Utils.TrySelectSpecificEntry([text, .. Lang.QuitRetainerMenu]);
     }
 
     internal static void EnforceSelectStringThrottle()
@@ -72,7 +72,7 @@ internal static unsafe class RetainerHandlers
         EnforceSelectStringThrottle();
         //2385	View venture report. (Complete)
         var text = Svc.Data.GetExcelSheet<Lumina.Excel.Sheets.Addon>().GetRow(2385).Text.ToDalamudString().GetText();
-        var ret = Utils.TrySelectSpecificEntry(text);
+        var ret = Utils.TrySelectSpecificEntry([text, .. Lang.ViewVentureReportComplete]);
         return ret;
     }
 
@@ -194,14 +194,14 @@ internal static unsafe class RetainerHandlers
     {
         //2378	Entrust or withdraw items.
         var text = Svc.Data.GetExcelSheet<Lumina.Excel.Sheets.Addon>().GetRow(2378).Text.ToDalamudString().GetText(true);
-        return Utils.TrySelectSpecificEntry(text);
+        return Utils.TrySelectSpecificEntry([text, .. Lang.EntrustOrWithdrawItems]);
     }
 
     internal static bool? SelectEntrustGil()
     {
         //2379	Entrust or withdraw gil.
         var text = Svc.Data.GetExcelSheet<Lumina.Excel.Sheets.Addon>().GetRow(2379).Text.ToDalamudString().GetText(true);
-        return Utils.TrySelectSpecificEntry(text);
+        return Utils.TrySelectSpecificEntry([text, .. Lang.EntrustOrWithdrawGil]);
     }
 
     internal static bool? ClickEntrustDuplicates()


### PR DESCRIPTION
Adds Spanish to `Lang.cs` alongside the seven languages already there, and passes the new literals next to the existing sheet reads in `RetainerHandlers` so official clients are unaffected.

Covered: the venture report, assign venture, entrust items and gil, quit, the four venture categories, the category prompt and the summoning bell name.

The literals are the plain forms, since the rows on screen carry a counter or a state and the match is `StartsWith`.

Tested in game: full retainer loop with no `TaskTimeoutException` and no bailouts.
